### PR TITLE
Add APSIS results to form_state values

### DIFF
--- a/src/Form/SubscribeForm.php
+++ b/src/Form/SubscribeForm.php
@@ -189,10 +189,13 @@ class SubscribeForm extends FormBase {
     }
 
     // Add subscriber(s).
+    $results = [];
     foreach ($subscribe_lists as $list) {
       $submit = $apsis->addSubscriber($list, $email, $name, $demographics);
-      drupal_set_message($this->t('Submitted!'));
+      $results[$list] = $submit->Message;
+      drupal_set_message(t($submit->Message));
     }
+    $form_state->setValue('results', $results);
   }
 
 }


### PR DESCRIPTION
  We could do this to have some kind of result code from APSIS,
  to use for submit handling further up the chain.
  Its a bit fragile to use the message as a result code,
  but APSIS API is always returning a result code of 1, so
  we cannot use that for anything.