### PR TITLE
Improve error handling by introducing exceptions.

### DIFF
--- a/apsis_mail.module
+++ b/apsis_mail.module
@@ -5,6 +5,7 @@
  * Apsis mail module file.
  */
 
+use Drupal\apsis_mail\Exception\ApsisException;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -30,7 +31,11 @@ function apsis_mail_form_user_form_alter(&$form, FormStateInterface $form_state)
   // Get apsis data.
   $apsis = \Drupal::service('apsis');
   $config = $apsis->config;
-  $mailing_lists = $apsis->getAllowedMailingLists();
+  try {
+    $mailing_lists = $apsis->getAllowedMailingLists();
+  } catch (ApsisException $e) {
+    $mailing_lists = [];
+  }
 
   // Get user info.
   $user = $form_state->getFormObject()->getEntity();
@@ -43,15 +48,17 @@ function apsis_mail_form_user_form_alter(&$form, FormStateInterface $form_state)
 
   // Proceed if roles are matching and there is allowed mailing lists.
   if (!empty(array_intersect($roles, $allowed_roles)) && !empty($mailing_lists)) {
-    $subscriber_id = $apsis->getSubscriberIdByEmail($email);
+    try {
+      $subscriber_id = $apsis->getSubscriberIdByEmail($email);
 
-    // Get subscribed lists directly from apsis to use as default value.
-    $lists_subscribed = [];
-    if ($subscriber_id) {
+      // Get subscribed lists directly from apsis to use as default value.
+      $lists_subscribed = [];
       $lists = $apsis->getSubscriberMailingLists($subscriber_id);
       foreach ($lists->Mailinglists as $list) {
         $lists_subscribed[] = $list->Id;
       }
+    } catch (ApsisException $e) {
+      $lists_subscribed = [];
     }
 
     $form['apsis'] = [
@@ -61,7 +68,11 @@ function apsis_mail_form_user_form_alter(&$form, FormStateInterface $form_state)
     ];
 
     // Render demographic data.
-    $allowedDemographicData = $apsis->getAllowedDemographicData();
+    try {
+      $allowedDemographicData = $apsis->getAllowedDemographicData();
+    } catch (ApsisException $e) {
+      $allowedDemographicData = [];
+    }
 
     $form['apsis']['apsis_demographic_data'] = [
       '#type' => 'fieldset',
@@ -70,12 +81,13 @@ function apsis_mail_form_user_form_alter(&$form, FormStateInterface $form_state)
     ];
 
     // Get Demograpic data states.
-    $user_info = $apsis->getSubscriberInfoByEmail($email);
-    $demographic_states = [];
-    if ($user_info) {
+    try {
+      $user_info = $apsis->getSubscriberInfoByEmail($email);
       foreach ($user_info->DemDataFields as $demdata) {
         $demographic_states[$demdata->Key] = $demdata->Value;
       }
+    } catch (ApsisException $e) {
+      $demographic_states = [];
     }
 
     foreach ($allowedDemographicData as $key => $demographic) {
@@ -120,17 +132,6 @@ function _apsis_mail_submit($form, FormStateInterface $form_state) {
   $email = $user->getEmail();
   $name = $user->getUsername();
 
-  $subscriber_id = $apsis->getSubscriberIdByEmail($email);
-
-  // Get subscribed lists directly from apsis to use as default value.
-  $lists_subscribed = [];
-  if ($subscriber_id) {
-    $lists = $apsis->getSubscriberMailingLists($subscriber_id);
-    foreach ($lists->Mailinglists as $list) {
-      $lists_subscribed[] = $list->Id;
-    }
-  }
-
   // Format demographic data.
   $demographics = [];
   foreach ($form_state->getValue('apsis_demographic_data') as $key => $value) {
@@ -157,6 +158,10 @@ function _apsis_mail_submit($form, FormStateInterface $form_state) {
   // Subscribe or unsubscribe to newsletters.
   $values = $form_state->getValues();
   foreach ($values['apsis_newsletter_signup'] as $list_id => $value) {
-    ($list_id == $value) ? $apsis->addSubscriber($list_id, $email, $name, $demographics) : $apsis->deleteSubscriber($list_id, $email);
+    try {
+      ($list_id == $value) ? $apsis->addSubscriber($list_id, $email, $name, $demographics) : $apsis->deleteSubscriber($list_id, $email);
+    } catch (ApsisException $e) {
+      watchdog_exception('apsis_mail', $e);
+    }
   }
 }

--- a/apsis_mail.services.yml
+++ b/apsis_mail.services.yml
@@ -6,10 +6,25 @@ services:
       - '@apsis.config'
       - '@cache.default'
       - '@datetime.time'
+      - '@apsis.exception_mapper'
   apsis.client:
     class: \GuzzleHttp\Client
     factory: ['@http_client_factory', 'fromOptions']
     arguments: []
+  apsis.exception_mapper:
+    class: Drupal\apsis_mail\Exception\ExceptionMapper
+    factory: ['Drupal\apsis_mail\Exception\ExceptionMapper', 'factory']
+    arguments:
+      -
+        - 'Drupal\apsis_mail\Exception\ApiDisabledException'
+        - 'Drupal\apsis_mail\Exception\BadRequestException'
+        - 'Drupal\apsis_mail\Exception\BusyException'
+        - 'Drupal\apsis_mail\Exception\InternalServerErrorException'
+        - 'Drupal\apsis_mail\Exception\InvalidSubscriberException'
+        - 'Drupal\apsis_mail\Exception\NotFoundException'
+        - 'Drupal\apsis_mail\Exception\OptOutSubscriberException'
+        - 'Drupal\apsis_mail\Exception\UnauthorizedException'
+        - 'Drupal\apsis_mail\Exception\ValidationErrorException'
   # Use this client when preparing for queuing subscriptions.
   apsis.prequeue:
     class: Drupal\apsis_mail\Apsis

--- a/src/Exception/ApiDisabledException.php
+++ b/src/Exception/ApiDisabledException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * API Disabled exception.
  *
@@ -17,9 +14,17 @@ class ApiDisabledException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -6, $code = 503, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -6;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 503;
   }
 
 }

--- a/src/Exception/ApiDisabledException.php
+++ b/src/Exception/ApiDisabledException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * API Disabled exception.
+ *
+ * Used if the API service is temporarily offline for maintenance and not
+ * available at the moment.
+ */
+class ApiDisabledException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -6, $code = 503, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/ApsisException.php
+++ b/src/Exception/ApsisException.php
@@ -14,39 +14,24 @@ use Throwable;
 class ApsisException extends \Exception {
 
   /**
-   * APSIS custom error code.
-   *
-   * @var int
-   */
-  protected $state;
-
-  /**
-   * ApsisException constructor.
-   *
-   * @param string $message
-   *   Exception message.
-   * @param int $state
-   *   Apsis custom error code.
-   * @param int $code
-   *   HTTP error code.
-   * @param Throwable|null $previous
-   *   Exception which this message was mapped from.
-   */
-  public function __construct($message, $state, $code = 0, Throwable $previous = null)
-  {
-    parent::__construct($message, $code, $previous);
-    $this->state = $state;
-  }
-
-  /**
-   * Returns the custom APSIS error code.
+   * Returns the custom APSIS error code corresponding to this exception type.
    *
    * @return int
    *   Custom APSIS error code
    */
-  public function getState()
-  {
-    return $this->state;
+  public static function getState() {
+    return NULL;
+  }
+
+
+  /**
+   * Returns the HTTP status code corresponding to this exception type.
+   *
+   * @return int
+   *   Custom APSIS error code
+   */
+  public static function getHttpStatus() {
+   return NULL;
   }
 
   /**
@@ -57,8 +42,7 @@ class ApsisException extends \Exception {
    * @return string|NULL
    *   Regular expression. NULL if the Apsis exception cannot be mapped using a match phrase.
    */
-  public function getMatchPhrase()
-  {
+  public static function getMatchPhrase() {
     return NULL;
   }
 

--- a/src/Exception/ApsisException.php
+++ b/src/Exception/ApsisException.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+use Throwable;
+
+/**
+ * Generic Apsis exception.
+ *
+ * Thrown if an error occours in the communication with the APSIS API.
+ *
+ * @see http://se.apidoc.anpdm.com/Help/GettingStarted/Getting%20started
+ */
+class ApsisException extends \Exception {
+
+  /**
+   * APSIS custom error code.
+   *
+   * @var int
+   */
+  protected $state;
+
+  /**
+   * ApsisException constructor.
+   *
+   * @param string $message
+   *   Exception message.
+   * @param int $state
+   *   Apsis custom error code.
+   * @param int $code
+   *   HTTP error code.
+   * @param Throwable|null $previous
+   *   Exception which this message was mapped from.
+   */
+  public function __construct($message, $state, $code = 0, Throwable $previous = null)
+  {
+    parent::__construct($message, $code, $previous);
+    $this->state = $state;
+  }
+
+  /**
+   * Returns the custom APSIS error code.
+   *
+   * @return int
+   *   Custom APSIS error code
+   */
+  public function getState()
+  {
+    return $this->state;
+  }
+
+  /**
+   * Return a regular expression which can be used to match against a custom APSIS error message.
+   *
+   * If the message matches the expression then the exception should be mapped to this type.
+   *
+   * @return string|NULL
+   *   Regular expression. NULL if the Apsis exception cannot be mapped using a match phrase.
+   */
+  public function getMatchPhrase()
+  {
+    return NULL;
+  }
+
+}

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Bad request exception.
  *
@@ -16,9 +13,17 @@ class BadRequestException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -7, $code = 503, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -7;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 503;
   }
 
 }

--- a/src/Exception/BadRequestException.php
+++ b/src/Exception/BadRequestException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Bad request exception.
+ *
+ * Used if the request is badly formatted.
+ */
+class BadRequestException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -7, $code = 503, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/BusyException.php
+++ b/src/Exception/BusyException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Busy exception
  *
@@ -16,9 +13,17 @@ class BusyException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -5, $code = 503, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -5;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 503;
   }
 
 }

--- a/src/Exception/BusyException.php
+++ b/src/Exception/BusyException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Busy exception
+ *
+ * Used if the API server is currently not available.
+ */
+class BusyException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -5, $code = 503, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/ExceptionMapper.php
+++ b/src/Exception/ExceptionMapper.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Mapper for transforming generic HTTP exceptions to specific ApsisExceptions.
+ *
+ * Officially APSIS uses a number of different types of errors. This set is
+ * larger than the number of used HTTP status codes. To distinguish between
+ * these APSIS also returns a custom error code referred to as state. Even
+ * between these there are different types of errors which can only be
+ * distinguished by inspecting the custom error message.
+ *
+ * This mapper is responsible for managing this process of determining the right
+ * custom exception type based on the generic HTTP exception.
+ *
+ * @see http://se.apidoc.anpdm.com/Help/GettingStarted/Getting%20started
+ */
+class ExceptionMapper
+{
+
+  /**
+   * The exception classes which can be mapped to.
+   *
+   * @var \ReflectionClass[]
+   */
+  protected $exceptionClasses = [];
+
+  /**
+   * ExceptionMapper constructor.
+   */
+  public function __construct() {
+  }
+
+  /**
+   * Register an exception which can be mapped to from this mapper.
+   *
+   * Exceptions must be a subclass of the ApsisException.
+   *
+   * @param string $className
+   *   The fully qualified exception class name.
+   */
+  public function registerException($className) {
+    $class = new \ReflectionClass($className);
+    if (!$class->isSubclassOf(ApsisException::class)) {
+      throw new \InvalidArgumentException(
+        sprintf('%s is not a valid %s', $class->getName(), ApsisException::class)
+      );
+    }
+    $this->exceptionClasses[] = $class;
+  }
+
+  /**
+   * Extract data from an Apsis request exception.
+   *
+   * @param RequestException $exception
+   *  Exception thrown as a result of calling the APSIS API.
+   *
+   * @return array
+   *   An array containing two entries:
+   *   - APSIS custom exception code
+   *   - Exception message
+   */
+  protected static function getExceptionData(RequestException $exception) {
+    $response = $exception->getResponse();
+    if ($response) {
+      $body = $response->getBody();
+      $exceptionData = json_decode($body->getContents());
+      $body->rewind();
+      return [$exceptionData->Code, $exceptionData->Message];
+    } else {
+      return [NULL, NULL];
+    }
+  }
+
+  /**
+   * Get ApsisException classes which use the same HTTP and APSIS error codes as the thrown exception.
+   *
+   * @param RequestException $httpException
+   *   The exception to map.
+   *
+   * @return array|\ReflectionClass[]
+   *   Matching exception classes based on HTTP and APSIS error codes.
+   */
+  protected function codeStateMatchStrategy(RequestException $httpException) {
+    /* @var \ReflectionClass[] $matchingExceptionClasses */
+    return array_filter($this->exceptionClasses, function(\ReflectionClass $class) use ($httpException) {
+      list($code, $message) = self::getExceptionData($httpException);
+      /* @var \Drupal\apsis_mail\Exception\ApsisException $apsisException */
+      $apsisException = $class->newInstance('dummy message');
+      return $apsisException->getCode() == $httpException->getCode() &&
+        $apsisException->getState() == $code;
+    });
+  }
+
+  /**
+   * Get ApsisException classes where the associared pattern matches message from the thrown exception.
+   *
+   * @param RequestException $httpException
+   *   The exception to map.
+   *
+   * @return array|\ReflectionClass[]
+   *   Matching exception classes based on message patterns.
+   */
+  protected function messageMatchStrategy(RequestException $httpException) {
+    /* @var \ReflectionClass[] $matchingExceptionClasses */
+    return array_filter($this->exceptionClasses, function(\ReflectionClass $class) use ($httpException) {
+      list($code, $message) = self::getExceptionData($httpException);
+      /* @var \Drupal\apsis_mail\Exception\ApsisException $apsisException */
+      $apsisException = $class->newInstance('dummy message');
+      return ($apsisException->getMatchPhrase()) ? preg_match($apsisException->getMatchPhrase(), $message) : FALSE;
+    });
+  }
+
+  /**
+   * Map a generic exception thrown as a result of calling the APSIS API to a custom APSIS exception.
+   *
+   * This should be a subclass of ApsisException which has been registered in this mapper. Alternately it can be or a
+   * generic ApsisException instance if it cannot be mapped to something more specific.
+   *
+   * @param RequestException $httpException
+   *   The generic exception to map.
+   *
+   * @return ApsisException
+   *   The corresponding custom APSIS exception instance.
+   */
+  public function map(RequestException $httpException) {
+    // Assemble a prioritized list of mapping strategies. Each may return an array of matching exception classes.
+    $strategies = [
+      function ($exception) {
+        return $this->messageMatchStrategy($exception);
+      },
+      function ($exception) {
+        return $this->codeStateMatchStrategy($exception);
+      },
+      function ($exception) {
+        return [new \ReflectionClass(ApsisException::class)];
+      }
+    ];
+
+    // Execute all strategies. The first one will be the target of the mapping.
+    $matchingExceptionClasses = array_reduce(
+      $strategies,
+      function(array $exceptionClasses, callable $strategy) use ($httpException) {
+        return array_merge($exceptionClasses, $strategy($httpException));
+      },
+      []
+    );
+    $exceptionClass = array_shift($matchingExceptionClasses);
+
+    // Finally create the mapped exception instance.
+    list($code, $message) = self::getExceptionData($httpException);
+    return $exceptionClass->newInstance($message, $code, $httpException->getCode(), $httpException);
+  }
+
+  /**
+   * Static factory method.
+   *
+   * @param string[] $classNames
+   *   Fully qualified classnames to exception classes which can be mapped to.
+   *
+   * @return ExceptionMapper
+   *   An ExceptionMapper instance with the classnames registered properly.
+   */
+  public static function factory(array $classNames) {
+    $mapper = new ExceptionMapper();
+    foreach ($classNames as $className) {
+      $mapper->registerException($className);
+    }
+    return $mapper;
+  }
+
+}

--- a/src/Exception/InternalServerErrorException.php
+++ b/src/Exception/InternalServerErrorException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Internal Server Error.
  *
@@ -17,9 +14,17 @@ class InternalServerErrorException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -1, $code = 500, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -1;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 500;
   }
 
 }

--- a/src/Exception/InternalServerErrorException.php
+++ b/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Internal Server Error.
+ *
+ * Used if there was an issue with the API server. You should contact APSIS
+ * support with the request details to get this resolved.
+ */
+class InternalServerErrorException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -1, $code = 500, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/InvalidSubscriberException.php
+++ b/src/Exception/InvalidSubscriberException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Thrown if an email does not correspond to a subscriber in APSIS.
  */
@@ -14,15 +11,7 @@ class InvalidSubscriberException extends ValidationErrorException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = NULL, $code = NULL, Throwable $previous = null)
-  {
-    parent::__construct($message, $state, $code, $previous);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getMatchPhrase()
+  public static function getMatchPhrase()
   {
     return '/no subscriber with email/';
   }

--- a/src/Exception/InvalidSubscriberException.php
+++ b/src/Exception/InvalidSubscriberException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Thrown if an email does not correspond to a subscriber in APSIS.
+ */
+class InvalidSubscriberException extends ValidationErrorException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = NULL, $code = NULL, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMatchPhrase()
+  {
+    return '/no subscriber with email/';
+  }
+
+}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Not found exception.
+ *
+ * Used if the URL is incorrect and no API method is found to deal with the request.
+ */
+class NotFoundException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -3, $code = 404, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Not found exception.
  *
@@ -16,9 +13,17 @@ class NotFoundException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -3, $code = 404, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -3;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 404;
   }
 
 }

--- a/src/Exception/OptOutSubscriberException.php
+++ b/src/Exception/OptOutSubscriberException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Thrown if an email cannot be added to a subscription list because the user is
  * on an opt-out list.
@@ -34,15 +31,7 @@ class OptOutSubscriberException extends ValidationErrorException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = NULL, $code = NULL, Throwable $previous = null)
-  {
-    parent::__construct($message, $state, $code, $previous);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getMatchPhrase()
+  public static function getMatchPhrase()
   {
     // Message in the format
     // "Subscriber with e-mail foo@bar.com exists on the Opt-out List."

--- a/src/Exception/OptOutSubscriberException.php
+++ b/src/Exception/OptOutSubscriberException.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Thrown if an email cannot be added to a subscription list because the user is
+ * on an opt-out list.
+ *
+ * Opt out list is when a subscriber opts out (opts not to receive more emails)
+ * from a specific list in APSIS Pro. A subscriber's email address that ends up
+ * on the "Opt out list" for a certain list in APSIS Pro cannot be added to that
+ * list again until a) the email address has been deleted from that "Opt out
+ * list" list or b) the email address re-subscribes to that list account through
+ * an APSIS Pro generated subscription form (form builder available in the APSIS
+ * Pro GUI). Opting out from a list does mean you may still be a subscriber to
+ * another list on that same account.
+ *
+ * Opt out all is when a subscriber opts out (opts not to receive more emails)
+ * from an APSIS Pro account (i.e most often an APSIS customer). A subscriber's
+ * email address that ends up on the "Opt out all" list in APSIS Pro cannot be
+ * added to the account again until a) the email address has been deleted from
+ * the Opt out all list or b) the email address re-subscribes to the account
+ * through an APSIS Pro generated subscription form (form builder available in
+ * the APSIS Pro GUI).
+ *
+ * @see http://se.apidoc.anpdm.com/Help/Terminology/Terminology
+ */
+class OptOutSubscriberException extends ValidationErrorException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = NULL, $code = NULL, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMatchPhrase()
+  {
+    // Message in the format
+    // "Subscriber with e-mail foo@bar.com exists on the Opt-out List."
+    return '/exists on the Opt-out/';
+  }
+
+}

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -2,24 +2,28 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Unauthorized exception.
  *
  * Represents lack of access rights to perform the API request, for example
  * using an invalid API key.
  */
-class UnauthorizedException extends ApsisException
-{
+class UnauthorizedException extends ApsisException {
 
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -4, $code = 403, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -4;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 403;
   }
 
 }

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Unauthorized exception.
+ *
+ * Represents lack of access rights to perform the API request, for example
+ * using an invalid API key.
+ */
+class UnauthorizedException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -4, $code = 403, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\apsis_mail\Exception;
+
+
+use Throwable;
+
+/**
+ * Validation error.
+ *
+ * Used if one or more parameters in the request are invalid.
+ */
+class ValidationErrorException extends ApsisException
+{
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct($message, $state = -2, $code = 400, Throwable $previous = null)
+  {
+    parent::__construct($message, $state, $code, $previous);
+  }
+
+}

--- a/src/Exception/ValidationErrorException.php
+++ b/src/Exception/ValidationErrorException.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\apsis_mail\Exception;
 
-
-use Throwable;
-
 /**
  * Validation error.
  *
@@ -16,9 +13,17 @@ class ValidationErrorException extends ApsisException
   /**
    * {@inheritdoc}
    */
-  public function __construct($message, $state = -2, $code = 400, Throwable $previous = null)
+  public static function getState()
   {
-    parent::__construct($message, $state, $code, $previous);
+    return -2;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getHttpStatus()
+  {
+    return 400;
   }
 
 }

--- a/src/Form/ApsisMailSettings.php
+++ b/src/Form/ApsisMailSettings.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\apsis_mail\Form;
 
+use Drupal\apsis_mail\Exception\ApsisException;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\ConfigFormBase;
 
@@ -109,7 +110,8 @@ class ApsisMailSettings extends ConfigFormBase {
       '#default_value' => $config->get('user_roles') ? $config->get('user_roles') : [],
     ];
 
-    if ($apsis->getMailingLists()) {
+    try {
+      $apsis_mailing_lists = $apsis->getMailingLists();
       $form['mailing_lists'] = [
         '#type' => 'details',
         '#title' => $this->t('Mailing lists'),
@@ -119,12 +121,15 @@ class ApsisMailSettings extends ConfigFormBase {
       $form['mailing_lists']['mailing_lists'] = [
         '#type' => 'checkboxes',
         '#title' => $this->t('Allowed mailing lists'),
-        '#options' => $apsis->getMailingLists(),
+        '#options' => $apsis_mailing_lists,
         '#default_value' => $mailing_lists ? $mailing_lists : [],
       ];
+    } catch (ApsisException $e) {
+      // Do nothing.
     }
 
-    if ($apsis->getDemographicData()) {
+    try {
+      $apsis_demographic_data = $apsis->getDemographicData();
       $form['demographic_data'] = [
         '#type' => 'details',
         '#title' => $this->t('Demographic data'),
@@ -150,7 +155,7 @@ class ApsisMailSettings extends ConfigFormBase {
         ],
       ];
 
-      foreach ($apsis->getDemographicData() as $key => $demographic) {
+      foreach ($apsis_demographic_data as $key => $demographic) {
         $alternatives = $demographic['alternatives'];
 
         $form['demographic_data']['demographic_data'][$key]['key'] = [
@@ -185,6 +190,8 @@ class ApsisMailSettings extends ConfigFormBase {
           '#default_value' => !empty($demographic_data[$key]['return_value']) ? $demographic_data[$key]['return_value'] : '',
         ];
       }
+    } catch (ApsisException $e) {
+      // Do nothing.
     }
 
     return parent::buildForm($form, $form_state);

--- a/src/Plugin/Block/ApsisMailSubscribeBlock.php
+++ b/src/Plugin/Block/ApsisMailSubscribeBlock.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\apsis_mail\Plugin\Block;
 
+use Drupal\apsis_mail\Exception\ApsisException;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\ConfigFactoryInterface;
@@ -57,10 +58,13 @@ class ApsisMailSubscribeBlock extends BlockBase implements ContainerFactoryPlugi
     ];
 
     // Get allowed mailing lists.
-    $mailing_lists = $apsis->getAllowedMailingLists();
-
-    // Get allowed demographic data.
-    $demographic_data = $apsis->getAllowedDemographicData();
+    try {
+      $mailing_lists = $apsis->getAllowedMailingLists();
+      $demographic_data = $apsis->getAllowedDemographicData();
+    } catch (ApsisException $e) {
+      $mailing_lists = [];
+      $demographic_data = [];
+    }
 
     // Display a link to the admin configuration,
     // if there is no allowed mailing lists.

--- a/tests/src/Unit/ExceptionMapperTest.php
+++ b/tests/src/Unit/ExceptionMapperTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\Tests\apsis_mail\Unit;
+
+use Drupal\apsis_mail\Exception\ApsisException;
+use Drupal\apsis_mail\Exception\ExceptionMapper;
+use Drupal\apsis_mail\Exception\InternalServerErrorException;
+use Drupal\apsis_mail\Exception\OptOutSubscriberException;
+use Drupal\apsis_mail\Exception\ValidationErrorException;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Test that the ExceptionMapper will map HTTP exceptions to APSIS exceptions.
+ */
+class ExceptionMapperTest extends UnitTestCase {
+
+  /**
+   * Test that an unrecognized exception is mapped to the generic exception.
+   */
+  public function testGenericMapping() {
+    $httpException = $this->generateException();
+
+    $exceptionMapper = new ExceptionMapper();
+    $exceptionMapper->registerException(InternalServerErrorException::class);
+    $apsisException =$exceptionMapper->map($httpException);
+    $this->assertEquals(ApsisException::class, get_class($apsisException));
+  }
+
+  /**
+   * Test that exceptions are mapped according to state and status.
+   */
+  public function testStateStatusMapping() {
+    $httpException = $this->generateException(
+      InternalServerErrorException::getHttpStatus(),
+      InternalServerErrorException::getState()
+    );
+
+    $exceptionMapper = new ExceptionMapper();
+    // Internal server error and opt out subscriber use the same status and
+    // error code. We add both to ensure that the correct one is mapped here.
+    $exceptionMapper->registerException(InternalServerErrorException::class);
+    $exceptionMapper->registerException(OptOutSubscriberException::class);
+    $apsisException = $exceptionMapper->map($httpException);
+    $this->assertEquals(InternalServerErrorException::class, get_class($apsisException));
+  }
+
+  /**
+   * Test that exceptions are mapped according to state and status.
+   */
+  public function testMatchPhraseMapping() {
+    $httpException = $this->generateException(
+      OptOutSubscriberException::getHttpStatus(),
+      OptOutSubscriberException::getState(),
+      'Subscriber with e-mail foo@bar.com exists on the Opt-out List.'
+    );
+
+    $exceptionMapper = new ExceptionMapper();
+    // Internal server error and opt out subscriber use the same status and
+    // error code. We add both to ensure that the correct one is mapped here.
+    $exceptionMapper->registerException(ValidationErrorException::class);
+    $exceptionMapper->registerException(OptOutSubscriberException::class);
+    $apsisException =$exceptionMapper->map($httpException);
+    $this->assertEquals(OptOutSubscriberException::class, get_class($apsisException));
+  }
+
+  /**
+   * Generate an HTTP exception for mapping.
+   *
+   * @param int $httpStatus
+   *   The HTTP status code use.
+   * @param int $apsisCode
+   *   The APSIS error code to contain within the exception.
+   * @param int $apsisMessage
+   *   The APSIS error message to contain within the exception.
+   *
+   * @return RequestException
+   *   The resulting exception.
+   */
+  public function generateException($httpStatus = 0, $apsisCode = 0, $apsisMessage = 'Some error occcured')
+  {
+    $httpException = new RequestException(
+      'Exception message',
+      new Request('GET', 'http://foo.bar'),
+      new Response(
+        $httpStatus,
+        [],
+        json_encode([
+          'Code' => $apsisCode,
+          'Message' => $apsisMessage
+        ])
+      )
+    );
+    return $httpException;
+  }
+
+}


### PR DESCRIPTION
Currently the Apsis class does not allow the caller to distinguish
Between different types of errors which may occur in the communication
with the APSIS API. All exceptions are caught and FALSE returned.

This change introduces a mapper which handles the rather complex logic
Of mapping from generic HTTP request exceptions to specific APSIS
Exceptions based on custom APSIS error codes and messages as well as 
HTTP status codes.

API callers are updated to handle the new exceptions and act 
accordingly.

Most importantly this means that we can handle queued subscriptions
correctly. If an email is on an opt-out list or the email is invalid
then there is no need to try to process the subscription at a later
point in time. Thus we avoid blocking the queue.

#SAMD8-578